### PR TITLE
Update squint GH action/cache  to v3

### DIFF
--- a/.github/workflows/squint.yml
+++ b/.github/workflows/squint.yml
@@ -23,7 +23,7 @@ jobs:
         java-version: 11
 
     - name: "Restore Cache"
-      uses: "actions/cache@v1"
+      uses: "actions/cache@v3"
       with:
         path: "~/.m2/repository"
         key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}"

--- a/squint/.github/workflows/ci.yml
+++ b/squint/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         java-version: 11
 
     - name: "Restore Cache"
-      uses: "actions/cache@v1"
+      uses: "actions/cache@v3"
       with:
         path: "~/.m2/repository"
         key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}"


### PR DESCRIPTION
Hi,

could you please consider patch to upgrade action/cache to v3. It attempts to address https://github.com/squint-cljs/squint/issues/280

I have not look into the details how the `deps.edn` caching could have made the CI freeze, but upgrading to v3 appears to unblock it.

Thanks